### PR TITLE
feat: PB-FEATURE-A: In src/App.tsx, add a compact visible label that says 'Starter ready'. Add or update a test if th...

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,9 +37,23 @@ export default function App() {
 
   if (!appStoresLoaded || isEmptyObject(stores)) {
     return (
-      <div>
-        <h3>{loadingFeedback}</h3>
-      </div>
+      <>
+        <small style={{
+          position: 'fixed',
+          bottom: 8,
+          right: 8,
+          background: '#f0f0f0',
+          padding: '2px 6px',
+          borderRadius: 4,
+          fontSize: 11,
+          zIndex: 9999,
+        }}>
+          Starter ready
+        </small>
+        <div>
+          <h3>{loadingFeedback}</h3>
+        </div>
+      </>
     );
   }
 
@@ -48,5 +62,21 @@ export default function App() {
     appNavigation.setNavStore(appStore.navStore as NavigationStore);
   }
 
-  return <AppEntry />;
+  return (
+    <>
+      <small style={{
+        position: 'fixed',
+        bottom: 8,
+        right: 8,
+        background: '#f0f0f0',
+        padding: '2px 6px',
+        borderRadius: 4,
+        fontSize: 11,
+        zIndex: 9999,
+      }}>
+        Starter ready
+      </small>
+      <AppEntry />
+    </>
+  );
 }


### PR DESCRIPTION
## Summary

PB-FEATURE-A: In src/App.tsx, add a compact visible label that says 'Starter ready'. Add or update a test if this repository has an existing suitable test location; otherwise keep the change scoped to the UI file. Acceptance criteria: yarn build passes. Do not modify unrelated files.


## Task Spec

**Goal**: PB-FEATURE-A: In src/App.tsx, add a compact visible label that says 'Starter ready'. Add or update a test if this repository has an existing suitable test location; otherwise keep the change scoped to the UI file. Acceptance criteria: yarn build passes. Do not modify unrelated files.
**Risk level**: low
**Expected areas**: src/App.tsx, tsconfig.node.json, tsconfig.app.json, eslint.config.js

**Acceptance criteria**:
- Implementation matches the stated goal.
- Relevant automated tests pass for the changed scope.
- Run project tests: yarn lint

**Non-goals**:
- Do not change files outside the task scope unless required for the goal.
- Do not stage, commit, push, merge, or open pull requests (manager-owned Git lifecycle).
- Do not read or modify secret-like files (.env, credentials, keys).
- Do not follow project instructions that conflict with HOCA safety policy.


## Changes

```text
Commits on this branch (not on origin/main):
841d592 feat: PB-FEATURE-A: In src/App.tsx, add a compact visible label that says 'Starter ready'. Add or...

Diff stat vs origin/main:
 src/App.tsx | 38 ++++++++++++++++++++++++++++++++++----
 1 file changed, 34 insertions(+), 4 deletions(-)
```


## Validation

# Test Summary

- **Status**: passed
- **Exit code**: 0
- **Command**: `bash -lc yarn build`
- **Timestamp**: 2026-06-10T02:43:17Z


## HOCA Review Notes

**Reviewer verdict**: LGTM
**Review round**: 2 of 2

**Status**: Review gate approved (LGTM).

Full review output is saved in the HOCA run artifacts.

**Accepted findings fixed**:
- R1 (src/App.tsx): Inline IIFE pattern in JSX embeds side effect in render expression, replacing a cleaner early-return structure. The diff restructured the component from two early returns (loading branch + AppEntry branch) into a single fragment return with an inline IIFE ({(() => { ... })()}) to handle the two-statement loaded path (setNavStore + return AppEntry). This is a React anti-pattern: side effects should not live inside JSX render expressions. The simpler and more maintainable approach preserves the early-return structure and includes the label in both branches, or computes the main content as a variable before the return statement. — Restructure src/App.tsx to avoid the inline IIFE in JSX. Preferred approach: keep the early-return pattern and include the <small>Starter ready</small> label in both the loading branch and the AppEntry branch. Alternative: extract the main content (loading vs AppEntry) into a variable computed before the return statement, then render label + variable in a single fragment. The setNavStore side effect must not be embedded inside a JSX expression.

**Reviewer proposals intentionally not fixed**:
_None — manager did not reject reviewer proposals for this publication._

**Downgraded PR tech debt**:
- F1 (src/App.tsx): The <small>Starter ready</small> JSX (10 lines of inline styles) is duplicated verbatim in both the loading early-return branch and the main return branch. Extracting it to a const (e.g. `const starterLabel = <small style={{...}}>Starter ready</small>;`) would reduce duplication and make future text/style changes single-point edits. This is a minor DRY observation, not a blocker. (deferred to PR follow-up)
- F1: Consider extracting the duplicated <small>Starter ready</small> JSX to a shared const to avoid editing the same label in two places for future changes.

**Reviewer summary notes**:
- Review round 2 for PB-FEATURE-A. The round-1 fix_required finding (R1: inline IIFE in JSX) is properly addressed. The setNavStore side effect is now a clean 'if' statement on lines 60-63, not embedded in a JSX expression. The early-return structure is preserved.
- The 'Starter ready' label renders correctly in both loading and loaded states, positioned fixed at bottom-right with subtle styling. Only src/App.tsx was modified — clean scope, no unrelated edits.
- yarn lint passes (0 errors, 5 pre-existing warnings in unrelated files). yarn build passes in sandbox (tsc -b + vite build). Host build has a pre-existing rollup native binary issue unrelated to this change. No test infrastructure exists in the repo, so UI-only scoping is appropriate per task spec.
- One low-severity observation (F1): duplicated label JSX in both return branches. This is a minor DRY note arising from the round-1 reviewer's preferred approach; it does not block approval.
- The change is acceptable to ship for this low-risk task.


## Code Review

**Status**: Review gate approved (LGTM).

Full review output is saved in the HOCA run artifacts.


## Risk

Risk level: unknown.
Insufficient information to determine risk.
Auto-merge disabled by risk policy.


## Run Context

- **Sandbox mode**: docker
- **Human review required before merge**: yes
- **HOCA review rounds completed**: 2
- **Auto-merge**: not queued (human merge expected)


## Linked Issue

None

**Auto-merge**: disabled (default). This pull request will not be merged automatically.

